### PR TITLE
Add instructions for adding repo key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ available by enabling `[atom]` repository in `/etc/pacman.conf`:
 Server = http://noaxiom.org/$repo/$arch
 ```
 
+You should also add the repo's key to your trusted keys:
+
+```sh
+sudo pacman-key -r B0544167
+sudo pacman-key --lsign-key B0544167
+```
+
 Check the Arch [wiki][atom-wiki] for more information.
 
 # Build method


### PR DESCRIPTION
The instructions for adding the repo to the system did not point out
that a GPG key needs to be added with pacman-key.

I've added these instructions as this tripped me up - what with this being my first unofficial repo and all.

See #11